### PR TITLE
Add Github link

### DIFF
--- a/pages/contribute.hbs
+++ b/pages/contribute.hbs
@@ -14,7 +14,7 @@ permalink: /contribute/
             <dt>"I found a mistake!"</dt>
             <dd>
                 The Week is written in a
-                <a href="fgkdgdfg">GitHub repo</a>.
+                <a href="https://github.com/dz4k/this-week-in-htmx">GitHub repo</a>.
                 You can find the post in question and edit it directly on GitHub or 
                 open an issue for us to look at.
             </dd>


### PR DESCRIPTION
I noticed that the Github link on the "Contribute" page had a placeholder; this fills it in.